### PR TITLE
chore: update ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,0 @@
-name: CI
-
-on: push
-
-jobs:
-  coverage:
-    uses: jill64/workflows/.github/workflows/coverage.yml@main

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # unfurl
 
 [![npm](https://img.shields.io/npm/v/%40jill64%2Funfurl)](https://npmjs.com/package/@jill64/unfurl)
-[![github-actions-ci](https://github.com/jill64/unfurl/actions/workflows/ci.yml/badge.svg)](https://github.com/jill64/unfurl/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/github/jill64/unfurl/graph/badge.svg?token=SC3Z3UKGRZ)](https://codecov.io/github/jill64/unfurl)
 
 Concurrently wait for a Promise mapped to an object while preserving the type

--- a/rsac.yml
+++ b/rsac.yml
@@ -1,5 +1,0 @@
-branch-protection:
-  main:
-    required_status_checks:
-      contexts:
-        - coverage / coverage


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Documentation: Removed the GitHub Actions CI badge from the project's README file.

This update is purely cosmetic and does not affect the functionality of the software. The removal of the badge indicates a change in the project's continuous integration process, but this is largely invisible to end-users. The software's performance, reliability, and usability remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->